### PR TITLE
Named sets

### DIFF
--- a/lib/Set/CrossProduct.pm
+++ b/lib/Set/CrossProduct.pm
@@ -9,6 +9,8 @@ use vars qw( $VERSION );
 
 $VERSION = '1.96';
 
+=encoding UTF-8
+
 =head1 NAME
 
 Set::CrossProduct - work with the cross product of two or more sets
@@ -90,7 +92,7 @@ too.
 
 	A => ( a, b, c )
 	B => ( )
-	
+
 In this case, A x B is the empty set, so you'll get no tuples.
 
 This module combines the arrays that give to it to create this

--- a/lib/Set/CrossProduct.pm
+++ b/lib/Set/CrossProduct.pm
@@ -17,7 +17,7 @@ Set::CrossProduct - work with the cross product of two or more sets
 
 =head1 SYNOPSIS
 
-	my $iterator = Set::CrossProduct->new( ARRAY_OF_ARRAYS );
+	my $iterator = Set::CrossProduct->new( (HASH||ARRAY)_REF_OF_ARRAY_REFS );
 
 	# get the number of tuples
 	my $number_of_tuples = $iterator->cardinality;
@@ -79,7 +79,7 @@ tuples shown:
 	( b, 2, foo )
 	( b, 2, bar )
 	( b, 3, foo )
-	( b, 3, bar ) 
+	( b, 3, bar )
 	( c, 1, foo )
 	( c, 1, bar )
 	( c, 2, foo )
@@ -98,7 +98,7 @@ In this case, A x B is the empty set, so you'll get no tuples.
 This module combines the arrays that give to it to create this
 cross product, then allows you to access the elements of the
 cross product in sequence, or to get all of the elements at
-once.  Be warned! The cardnality of the cross product, that is,
+once.  Be warned! The cardinality of the cross product, that is,
 the number of elements in the cross product, is the product of
 the cardinality of all of the sets.
 
@@ -118,14 +118,13 @@ code.  Of course, your use is probably more interesting. :)
 
 =head1 METHODS
 
-=head2 new( ARRAY_REF_OF_ARRAY_REFS )
+=head2 new( (HASH|ARRAY)_REF_OF_ARRAY_REFS )
 
-Given the array of arrays that represent some sets, return a
-C<Set::CrossProduct> instance that represents the cross product
-of those sets.
+Given arrays that represent some sets, return a C<Set::CrossProduct>
+instance that represents the cross product of those sets.
 
-The single argument is an array reference that has as its
-elements other array references.  The C<new> method will
+The single argument is a hash or array reference that has as
+its elements array references.  The C<new> method will
 return undef in scalar context and the empty list in list
 context if you give it something different.
 
@@ -270,7 +269,7 @@ of tuples, which is the product of the number of elements in
 each set.
 
 Strict set theorists will realize that this isn't necessarily
-the real cardinality since some tuples may be indentical, making
+the real cardinality since some tuples may be identical, making
 the actual cardinality smaller.
 
 =cut
@@ -312,8 +311,13 @@ sub reset_cursor
 Return the next tuple from the cross product, and move the position
 to the tuple after it.
 
+When the object was constructed from an array ref:
 In list context, C<get> returns the tuple as a list.  In scalar context
 C<get> returns the tuple as an array reference.
+
+When the object was constructed from a hash ref:
+In list context, C<get> returns the tuple as a hash.  In scalar context
+C<get> returns the tuple as a hash reference.
 
 If you have already gotten the last tuple in
 the cross product, then C<get> returns undef in scalar context and
@@ -392,10 +396,15 @@ Return the next tuple, but do not move the pointer.  This
 way you can look at the next value without affecting your
 position in the cross product.
 
-In list context, C<get> returns the tuple as a list.  In scalar context
-C<get> returns the tuple as an array reference.
+When the object was constructed from an array ref:
+In list context, C<next> returns the tuple as a list.  In scalar context
+C<next> returns the tuple as an array reference.
 
-For the last combination, next() returns undef.
+When the object was constructed from a hash ref:
+In list context, C<next> returns the tuple as a hash.  In scalar context
+C<next> returns the tuple as a hash reference.
+
+For the last combination, C<next> returns undef.
 
 =cut
 
@@ -417,8 +426,13 @@ Return the previous tuple, but do not move the pointer.  This
 way you can look at the last value without affecting your
 position in the cross product.
 
-In list context, C<get> returns the tuple as a list.  In scalar context
-C<get> returns the tuple as an array reference.
+When the object was constructed from an array ref:
+In list context, C<previous> returns the tuple as a list.  In scalar context
+C<previous> returns the tuple as an array reference.
+
+When the object was constructed from a hash ref:
+In list context, C<previous> returns the tuple as a hash.  In scalar context
+C<previous> returns the tuple as a hash reference.
 
 =cut
 
@@ -435,7 +449,7 @@ sub previous
 =head2 done()
 
 Without an argument, C<done> returns true if there are no more
-combinations to fetch with C<get>. and returns false otherwise.
+combinations to fetch with C<get> and returns false otherwise.
 
 With an argument, it acts as if there are no more arguments to fetch, no
 matter the value. If you want to start over, use C<reset_cursor> instead.
@@ -448,8 +462,13 @@ sub done { $_[0]->{done} = 1 if @_ > 1; $_[0]->{done} }
 
 Return a random tuple from the cross product.
 
-In list context, C<get> returns the tuple as a list.  In scalar context
-C<get> returns the tuple as an array reference.
+When the object was constructed from an array ref:
+In list context, C<random> returns the tuple as a list.  In scalar context
+C<random> returns the tuple as an array reference.
+
+When the object was constructed from a hash ref:
+In list context, C<random> returns the tuple as a hash.  In scalar context
+C<random> returns the tuple as an array reference.
 
 =cut
 
@@ -465,14 +484,12 @@ sub random
 
 =head2 combinations()
 
-Returns a reference to an arrray that contains all of the tuples
+Returns a reference to an array that contains all of the tuples
 of the cross product.  This can be quite large, so you might
 want to check the cardinality first.
 
-In list context, C<get> returns the tuple as a list.  In scalar context
-C<get> returns the tuple as an array reference.  However, you should
-probably always use this in scalar context except for very low
-cardnalities to avoid returning huge lists.
+You should probably always use this in scalar context except for
+very low cardinalities to avoid huge return values.
 
 =cut
 
@@ -492,19 +509,6 @@ sub combinations
 	}
 
 =head1 TO DO
-
-* it would be nice to be able to name the sets, and then access
-elements from a tuple by name, like
-
-	my $i = Set::CrossProduct->new( {
-			Apples => [ ... ],
-			Oranges => [ ... ],
-			}
-		);
-
-	my $tuple = $i->get;
-
-	my $apple = $tuple->Apples;
 
 * I need to fix the cardinality method. it returns the total number
 of possibly non-unique tuples.

--- a/script/cross
+++ b/script/cross
@@ -19,6 +19,9 @@ while( my $tuple = $iterator->get )
 	print "\n";
 	}
 	
+
+=encoding UTF-8
+
 =head1 NAME
 
 cross - output the cross product of two or more sets
@@ -26,14 +29,14 @@ cross - output the cross product of two or more sets
 =head1 SYNOPSIS
 
 	cross [-g gluestring] "item,item,item" "item,item,item" ...
-	
+
 	prompt> cross "a,b,c" "1,2,3"
 	a 1
 	a 2
 	a 3
 	b 1
 	...
-	
+
 	prompt> cross "a,b,c" "1,2,3" "x,y,z"
 	a 1 x
 	a 1 y

--- a/t/test_manifest
+++ b/t/test_manifest
@@ -3,6 +3,7 @@ pod.t
 pod_coverage.t
 #prereq.t
 tuple.t
+tuple_hr.t
 next.t
 error.t
 empty_set.t

--- a/t/tuple_hr.t
+++ b/t/tuple_hr.t
@@ -1,0 +1,48 @@
+use Test::More 0.95;
+
+my $class = 'Set::CrossProduct';
+use_ok( $class );
+
+my @apples  = ('Granny Smith', 'Washington', 'Red Delicious');
+my @oranges = ('Navel', 'Florida');
+
+my $i = Set::CrossProduct->new( { Apples =>  \@apples, Oranges => \@oranges } );
+isa_ok( $i, $class );
+
+is( $i->cardinality, 6, 'Cardinality is 6' );
+
+my $tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[0] and $tuple->{Oranges} eq $oranges[0] );
+
+$tuple = $i->next;
+ok( $tuple->{Apples} eq $apples[0] and $tuple->{Oranges} eq $oranges[1] );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[0] and $tuple->{Oranges} eq $oranges[1] );
+
+$tuple = $i->previous;
+ok( $tuple->{Apples} eq $apples[0] and $tuple->{Oranges} eq $oranges[1] );
+
+is_deeply($tuple, {Apples => $apples[0], Oranges => $oranges[1]}, 'Explicit exact tuple check');
+
+$status = $i->unget;
+ok( $status );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[0] and $tuple->{Oranges} eq $oranges[1] );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[1] and $tuple->{Oranges} eq $oranges[0] );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[1] and $tuple->{Oranges} eq $oranges[1] );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[2] and $tuple->{Oranges} eq $oranges[0] );
+
+$tuple = $i->get;
+ok( $tuple->{Apples} eq $apples[2] and $tuple->{Oranges} eq $oranges[1] );
+
+ok( !( defined $i->get ), 'Next element is undefined after get' );
+
+done_testing();


### PR DESCRIPTION
This addresses part of the POD "TO DO" section, allowing for named sets via a supplied hash reference.

When constructed from a hash reference, the returned tuples are also plain hash references.  This is, perhaps, not quite as nice as the suggested syntax in the TO DO (`$tuple->{Apples}` v `$tuple->Apples`), but it seems (to me) to be in line with how the rest of the package works.

I have updated the documentation a bit to reflect this change, but have not done any of the `$VERSION` or related house keeping to make this ready for distribution.

I have tried to maintain the code in the original style and apologize in advance for errors along those lines.

I explicitly disclaim copyright for the code and changes in this pull request.  If that is not possible, I hereby assign copyright for any and all code and changes in this pull request to @briandfoy.